### PR TITLE
Move Action metadata to action.yml file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ LABEL "maintainer"="Andrew Starr-Bochicchio <asb@digitalocean.com>"
 LABEL "repository"="https://github.com/digitalocean/action-doctl"
 LABEL "homepage"="https://github.com/digitalocean/action-doctl"
 
-LABEL "com.github.actions.name"="GitHub Action for DigitalOcean - doctl"
-LABEL "com.github.actions.description"="Use doctl to manage your DigitalOcean resources."
-LABEL "com.github.actions.icon"="droplet"
-LABEL "com.github.actions.color"="blue"
-
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "help" ]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,9 @@
+name: 'GitHub Action for DigitalOcean - doctl'
+description: 'Use doctl to manage your DigitalOcean resources.'
+author: 'Andrew Starr-Bochicchio <asb@digitalocean.com>'
+branding:
+  icon: 'droplet'
+  color: 'blue'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'


### PR DESCRIPTION
Actions in the marketplace now must have an `action.yml` file as per https://help.github.com/en/actions/automating-your-workflow-with-github-actions/publishing-actions-in-github-marketplace