### PR TITLE
Use pull_request_target rather than pull_request in workflow.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request_target]
 name: Test and lint
 
 jobs:


### PR DESCRIPTION
As the integration tests require access to a secret, this update is needed in order to prevent failures when a PR is opened from outside the org as seen in  https://github.com/digitalocean/action-doctl/pull/36


https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/

> In order to solve this, we’ve added a new pull_request_target event, which behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request. This means the workflow is running from a trusted source and is given access to a read/write token as well as secrets enabling the maintainer to safely comment on or label a pull request. 