### PR TITLE
Bump fallback version to most recent release.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5361,7 +5361,7 @@ const tc = __webpack_require__(533);
 const { Octokit } = __webpack_require__(889);
 
 const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download"
-const fallbackVersion = "1.42.0"
+const fallbackVersion = "1.73.1"
 const octokit = new Octokit();
 
 async function downloadDoctl(version) {
@@ -5378,7 +5378,7 @@ async function downloadDoctl(version) {
 }
 
 async function run() {
-  try { 
+  try {
     var version = core.getInput('version');
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const tc = require('@actions/tool-cache');
 const { Octokit } = require("@octokit/rest");
 
 const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download"
-const fallbackVersion = "1.42.0"
+const fallbackVersion = "1.73.1"
 const octokit = new Octokit();
 
 async function downloadDoctl(version) {
@@ -21,7 +21,7 @@ async function downloadDoctl(version) {
 }
 
 async function run() {
-  try { 
+  try {
     var version = core.getInput('version');
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({


### PR DESCRIPTION
Use a modern version of `doctl` with support for the `--expiry-seconds` flag for `registry login` as the fallback version.

Fixes: https://github.com/do-community/example-doctl-action/pull/15