### PR TITLE
Register token as secret.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5908,6 +5908,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     var token = core.getInput('token', { required: true });
+    core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);
     core.info('>>> Successfully logged into doctl');
   }

--- a/main.js
+++ b/main.js
@@ -52,6 +52,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     var token = core.getInput('token', { required: true });
+    core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);
     core.info('>>> Successfully logged into doctl');
   }


### PR DESCRIPTION
When used as documented, GitHub redacts the token in logs. We should still register it as a secret to ensure that it is not accidentally leaked when miss used.
 
https://github.com/actions/toolkit/tree/main/packages/core#setting-a-secret