### PR TITLE
Use process over os for backwards compatibility.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17455,7 +17455,6 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 var __webpack_exports__ = {};
 // This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
 (() => {
-const os = __nccwpck_require__(2037);
 const core = __nccwpck_require__(2186);
 const exec = __nccwpck_require__(1514);
 const tc = __nccwpck_require__(7784);
@@ -17465,40 +17464,39 @@ const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download
 const fallbackVersion = "1.98.1";
 const octokit = new Octokit();
 
-async function downloadDoctl(version, osType, osMachine) {
+async function downloadDoctl(version, type, architecture) {
     var platform = 'linux';
     var arch = 'amd64';
     var extension = 'tar.gz';
 
-    switch (osType) {
-        case 'Darwin': 
+    switch (type) {
+        case 'darwin':
             platform = 'darwin';
             break;
-        case 'Windows_NT':
+        case 'win32':
             platform = 'windows';
             extension = 'zip'
             break;
-        case 'Linux':
+        case 'linux':
             platform = 'linux';
             break;
         default:
-            core.warning(`unknown platform: ${osType}; defaulting to ${platform}`);
+            core.warning(`unknown platform: ${type}; defaulting to ${platform}`);
             break;
     }
 
-    switch (osMachine) {
+    switch (architecture) {
         case 'arm64': 
             arch = 'arm64';
             break;
-        case 'x86_64':
+        case 'x64':
             arch = 'amd64';
             break;
-        case 'i386':
-        case 'i686':
+        case 'ia32':
             arch = '386';
             break;
         default:
-            core.warning(`unknown architecture: ${osMachine}; defaulting to ${arch}`);
+            core.warning(`unknown architecture: ${architecture}; defaulting to ${arch}`);
             break;
     }
 
@@ -17534,7 +17532,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
 
     var path = tc.find("doctl", version);
     if (!path) {
-        const installPath = await downloadDoctl(version, os.type(), os.machine());
+        const installPath = await downloadDoctl(version, process.platform, process.arch);
         path = await tc.cacheDir(installPath, 'doctl', version);
     }
     core.addPath(path);

--- a/main.js
+++ b/main.js
@@ -1,4 +1,3 @@
-const os = require('os');
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 const tc = require('@actions/tool-cache');
@@ -8,40 +7,39 @@ const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download
 const fallbackVersion = "1.98.1";
 const octokit = new Octokit();
 
-async function downloadDoctl(version, osType, osMachine) {
+async function downloadDoctl(version, type, architecture) {
     var platform = 'linux';
     var arch = 'amd64';
     var extension = 'tar.gz';
 
-    switch (osType) {
-        case 'Darwin': 
+    switch (type) {
+        case 'darwin':
             platform = 'darwin';
             break;
-        case 'Windows_NT':
+        case 'win32':
             platform = 'windows';
             extension = 'zip'
             break;
-        case 'Linux':
+        case 'linux':
             platform = 'linux';
             break;
         default:
-            core.warning(`unknown platform: ${osType}; defaulting to ${platform}`);
+            core.warning(`unknown platform: ${type}; defaulting to ${platform}`);
             break;
     }
 
-    switch (osMachine) {
+    switch (architecture) {
         case 'arm64': 
             arch = 'arm64';
             break;
-        case 'x86_64':
+        case 'x64':
             arch = 'amd64';
             break;
-        case 'i386':
-        case 'i686':
+        case 'ia32':
             arch = '386';
             break;
         default:
-            core.warning(`unknown architecture: ${osMachine}; defaulting to ${arch}`);
+            core.warning(`unknown architecture: ${architecture}; defaulting to ${arch}`);
             break;
     }
 
@@ -77,7 +75,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
 
     var path = tc.find("doctl", version);
     if (!path) {
-        const installPath = await downloadDoctl(version, os.type(), os.machine());
+        const installPath = await downloadDoctl(version, process.platform, process.arch);
         path = await tc.cacheDir(installPath, 'doctl', version);
     }
     core.addPath(path);


### PR DESCRIPTION
`os` was added in Node 16. Even though [we specify that we run on Node 16](https://github.com/digitalocean/action-doctl/blob/595d91dabf2c6f9194ba08393311cba86e45b6ae/action.yml#L15) and it is the oldest currently supported release upstream, self-host runners may not be properly configured to provide the same environment as GitHub hosted runners. So this switches to using `process` for greater backwards compatibility.

The drawback to this approach is that `os` reports information about the actual operating system while `process` reports information about the node binary itself. Though in most cases that should be fine.

Closes: https://github.com/digitalocean/action-doctl/issues/76