### PR TITLE
Add no_auth option (Fixes #67)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,6 +39,26 @@ jobs:
       - name: Verify log-in
         run: doctl compute region list
 
+  test_no_auth:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install doctl
+        uses: ./
+        with:
+          no_auth: true
+
+      - name: Verify installation
+        run: doctl version
+
+      - name: Verify not authenticated
+        run: |
+          doctl compute region list 2>&1 | grep -qi "Unable to initialize DigitalOcean API client: access token is required"
+
   test_custom_version_linux_and_mac:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
+- `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
 - `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
-  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate --schema-only`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
 - `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
-  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate-offline`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 - `token` – (**Required**) A DigitalOcean personal access token ([more info](https://docs.digitalocean.com/reference/api/create-personal-access-token/)).
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
 - `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
-  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate-offline`)
+  - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate`)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See [this repository](https://github.com/do-community/example-doctl-action) for 
 - `version` – (Optional) The version of `doctl` to install. If excluded, the latest release will be used.
 - `no_auth` – (Optional) Set to `true` to skip the authentication step. The API `token` parameter is _Optional_ in this case.
   - _Note:_ This can be useful when running in workflows in untrusted environments, or where auth isn't necessary (e.g. `doctl app spec validate --schema-only`)
+  - This depends on `doctl >= v1.101.0` (digitalocean/doctl#1450)
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,12 @@ inputs:
   version:
     description: 'Version of doctl to install'
     default: 'latest'
+  no_auth:
+    description: 'Skip authentication'
+    default: 'false'
   token:
     description: 'DigitalOcean API Token'
-    required: true
+    default: ''
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17538,6 +17538,14 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.addPath(path);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
+    // Skip authentication if requested
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    var no_auth = core.getInput('no_auth');
+    if (no_auth.toLowerCase() === 'true') {
+      core.info('>>> Skipping doctl auth');
+      return;
+    }
+
     var token = core.getInput('token', { required: true });
     core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -17539,7 +17539,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate --schema-only)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/dist/index.js
+++ b/dist/index.js
@@ -17539,7 +17539,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/dist/index.js
+++ b/dist/index.js
@@ -17539,7 +17539,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/main.js
+++ b/main.js
@@ -81,6 +81,14 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.addPath(path);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
+    // Skip authentication if requested
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    var no_auth = core.getInput('no_auth');
+    if (no_auth.toLowerCase() === 'true') {
+      core.info('>>> Skipping doctl auth');
+      return;
+    }
+
     var token = core.getInput('token', { required: true });
     core.setSecret(token);
     await exec.exec('doctl auth init -t', [token]);

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate-offline)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
     core.info(`>>> doctl version v${version} installed to ${path}`);
 
     // Skip authentication if requested
-    // for workflows where auth isn't necessary (e.g. doctl app spec validate)
+    // for workflows where auth isn't necessary (e.g. doctl app spec validate --schema-only)
     var no_auth = core.getInput('no_auth');
     if (no_auth.toLowerCase() === 'true') {
       core.info('>>> Skipping doctl auth');


### PR DESCRIPTION
As a followup to digitalocean/doctl#1450, this PR adds a `no_auth` option to this GitHub Action.  This pull request if merged will fix #67 by making the `token` parameter optional when `no_auth: true` is passed.

Notes: My work on this PR was done as part of [DigitalOcean + MLH's Hacktoberfest][1] + [Global Hack Week: Open Source][2].

By the way, I think that there are 2 tags required for the [Hacktoberfest profile page][3] to qualify a PR for credit towards Hacktoberfest:

- `Hacktoberfest`: For a PR to show up in the list of participating project PRs
- `Hacktoberfest-accepted`: When the PR is accepted

The one for digitalocean/doctl#1450 still isn't shown as participating on that page when I checked today. 

[1]: https://news.mlh.io/mlh-partners-with-digitaloceans-10th-hacktoberfest-for-global-hack-week-open-source-09-01-2023
[2]: https://ghw.mlh.io/events/open-source
[3]: https://hacktoberfest.com/profile/