### PR TITLE
Update to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'DigitalOcean API Token'
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
fixes #81 

Node 16 is deprecated and warnings are shown in workflow runs.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/