### PR TITLE
Added fallback mechanism for faulty release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10885,6 +10885,20 @@ const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download
 const fallbackVersion = "1.98.1";
 const octokit = new Octokit();
 
+async function getRecentReleases(count = 5) {
+    try {
+        const response = await octokit.repos.listReleases({
+            owner: 'digitalocean',
+            repo: 'doctl',
+            per_page: count
+        });
+        return response.data.map(release => release.name);
+    } catch (error) {
+        core.warning(`Failed to fetch recent releases: ${error.message}`);
+        return [fallbackVersion];
+    }
+}
+
 async function downloadDoctl(version, type, architecture) {
     var platform = 'linux';
     var arch = 'amd64';
@@ -10923,14 +10937,51 @@ async function downloadDoctl(version, type, architecture) {
 
     const downloadURL = `${baseDownloadURL}/v${version}/doctl-${version}-${platform}-${arch}.${extension}`;
     core.debug(`doctl download url: ${downloadURL}`);
-    const doctlDownload = await tc.downloadTool(downloadURL);
+    
+    try {
+        const doctlDownload = await tc.downloadTool(downloadURL);
+        return tc.extractTar(doctlDownload);
+    } catch (error) {
+        core.warning(`Failed to download doctl v${version}: ${error.message}`);
+        throw new Error(`Download failed for version ${version}: ${error.message}`);
+    }
+}
 
-    return tc.extractTar(doctlDownload);
+async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
+    // If a specific version was requested, try it first
+    if (requestedVersion !== 'latest') {
+        try {
+            core.info(`Attempting to download doctl v${requestedVersion}`);
+            return await downloadDoctl(requestedVersion, type, architecture);
+        } catch (error) {
+            core.warning(`Failed to download requested version v${requestedVersion}, will try recent versions`);
+        }
+    }
+
+    // Get recent releases and try them in order
+    const recentReleases = await getRecentReleases(5);
+    
+    for (const version of recentReleases) {
+        try {
+            core.info(`Attempting to download doctl v${version}`);
+            const installPath = await downloadDoctl(version, type, architecture);
+            core.info(`Successfully downloaded doctl v${version}`);
+            return { installPath, version };
+        } catch (error) {
+            core.warning(`Failed to download doctl v${version}, trying next version`);
+            continue;
+        }
+    }
+
+    // If all recent versions fail, throw an error
+    throw new Error(`Failed to download doctl. Tried versions: ${recentReleases.join(', ')}`);
 }
 
 async function run() {
   try {
     var version = core.getInput('version');
+    var requestedVersion = version;
+    
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({
             owner: 'digitalocean',
@@ -10946,18 +10997,32 @@ async function run() {
 Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
             return fallbackVersion;
         });
+        requestedVersion = 'latest';
     }
     if (version.charAt(0) === 'v') {
         version = version.substr(1);
     }
 
     var path = tc.find("doctl", version);
+    var actualVersion = version;
+    
     if (!path) {
-        const installPath = await downloadDoctl(version, process.platform, process.arch);
-        path = await tc.cacheDir(installPath, 'doctl', version);
+        try {
+            // Try the requested/latest version first
+            const installPath = await downloadDoctl(version, process.platform, process.arch);
+            path = await tc.cacheDir(installPath, 'doctl', version);
+            actualVersion = version;
+        } catch (error) {
+            // If the download fails (e.g., missing artifacts), try fallback versions
+            core.warning(`Failed to download doctl v${version}, trying fallback versions`);
+            const result = await downloadDoctlWithFallback(requestedVersion, process.platform, process.arch);
+            path = await tc.cacheDir(result.installPath, 'doctl', result.version);
+            actualVersion = result.version;
+        }
     }
+    
     core.addPath(path);
-    core.info(`>>> doctl version v${version} installed to ${path}`);
+    core.info(`>>> doctl version v${actualVersion} installed to ${path}`);
 
     // Skip authentication if requested
     // for workflows where auth isn't necessary (e.g. doctl app spec validate --schema-only)

--- a/main.js
+++ b/main.js
@@ -7,6 +7,20 @@ const baseDownloadURL = "https://github.com/digitalocean/doctl/releases/download
 const fallbackVersion = "1.98.1";
 const octokit = new Octokit();
 
+async function getRecentReleases(count = 5) {
+    try {
+        const response = await octokit.repos.listReleases({
+            owner: 'digitalocean',
+            repo: 'doctl',
+            per_page: count
+        });
+        return response.data.map(release => release.name);
+    } catch (error) {
+        core.warning(`Failed to fetch recent releases: ${error.message}`);
+        return [fallbackVersion];
+    }
+}
+
 async function downloadDoctl(version, type, architecture) {
     var platform = 'linux';
     var arch = 'amd64';
@@ -45,14 +59,51 @@ async function downloadDoctl(version, type, architecture) {
 
     const downloadURL = `${baseDownloadURL}/v${version}/doctl-${version}-${platform}-${arch}.${extension}`;
     core.debug(`doctl download url: ${downloadURL}`);
-    const doctlDownload = await tc.downloadTool(downloadURL);
+    
+    try {
+        const doctlDownload = await tc.downloadTool(downloadURL);
+        return tc.extractTar(doctlDownload);
+    } catch (error) {
+        core.warning(`Failed to download doctl v${version}: ${error.message}`);
+        throw new Error(`Download failed for version ${version}: ${error.message}`);
+    }
+}
 
-    return tc.extractTar(doctlDownload);
+async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
+    // If a specific version was requested, try it first
+    if (requestedVersion !== 'latest') {
+        try {
+            core.info(`Attempting to download doctl v${requestedVersion}`);
+            return await downloadDoctl(requestedVersion, type, architecture);
+        } catch (error) {
+            core.warning(`Failed to download requested version v${requestedVersion}, will try recent versions`);
+        }
+    }
+
+    // Get recent releases and try them in order
+    const recentReleases = await getRecentReleases(5);
+    
+    for (const version of recentReleases) {
+        try {
+            core.info(`Attempting to download doctl v${version}`);
+            const installPath = await downloadDoctl(version, type, architecture);
+            core.info(`Successfully downloaded doctl v${version}`);
+            return { installPath, version };
+        } catch (error) {
+            core.warning(`Failed to download doctl v${version}, trying next version`);
+            continue;
+        }
+    }
+
+    // If all recent versions fail, throw an error
+    throw new Error(`Failed to download doctl. Tried versions: ${recentReleases.join(', ')}`);
 }
 
 async function run() {
   try {
     var version = core.getInput('version');
+    var requestedVersion = version;
+    
     if ((!version) || (version.toLowerCase() === 'latest')) {
         version = await octokit.repos.getLatestRelease({
             owner: 'digitalocean',
@@ -68,18 +119,32 @@ async function run() {
 Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
             return fallbackVersion;
         });
+        requestedVersion = 'latest';
     }
     if (version.charAt(0) === 'v') {
         version = version.substr(1);
     }
 
     var path = tc.find("doctl", version);
+    var actualVersion = version;
+    
     if (!path) {
-        const installPath = await downloadDoctl(version, process.platform, process.arch);
-        path = await tc.cacheDir(installPath, 'doctl', version);
+        try {
+            // Try the requested/latest version first
+            const installPath = await downloadDoctl(version, process.platform, process.arch);
+            path = await tc.cacheDir(installPath, 'doctl', version);
+            actualVersion = version;
+        } catch (error) {
+            // If the download fails (e.g., missing artifacts), try fallback versions
+            core.warning(`Failed to download doctl v${version}, trying fallback versions`);
+            const result = await downloadDoctlWithFallback(requestedVersion, process.platform, process.arch);
+            path = await tc.cacheDir(result.installPath, 'doctl', result.version);
+            actualVersion = result.version;
+        }
     }
+    
     core.addPath(path);
-    core.info(`>>> doctl version v${version} installed to ${path}`);
+    core.info(`>>> doctl version v${actualVersion} installed to ${path}`);
 
     // Skip authentication if requested
     // for workflows where auth isn't necessary (e.g. doctl app spec validate --schema-only)


### PR DESCRIPTION
The workflow breaks if the doctl release is faulty and is missing artifacts. Added fallback mechanism to try for the previous 5 versions in case the requested version is faulty. If none of them work it'll fallback to the fallback version.

This aims at solving [Issue 92](https://github.com/digitalocean/action-doctl/issues/92)