### PR TITLE
changed pull_request_target to pull_request

### DIFF
--- a/.github/workflows/pr-label-gate.yml
+++ b/.github/workflows/pr-label-gate.yml
@@ -1,0 +1,21 @@
+name: PR Label Gate
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-fork-acknowledgment:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for acknowledgment label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (!labels.includes('post-merge-tests-ack')) {
+              core.setFailed(
+                'A reviewer with write access must add the "post-merge-tests-ack" label to acknowledge that tests will be verified post-merge.'
+              );
+            }

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request_target]
+on: [push, pull_request]
 name: Test and lint
 
 jobs:
@@ -6,13 +6,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - run: npm test
 
   package_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: "Ensure that code has been packaged and commited"
         run: |-
             npm install
@@ -21,12 +21,13 @@ jobs:
               (echo -e "\nPlease run 'npm run package' and commit the results" && exit 1)
 
   test:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Install doctl
         uses: ./
@@ -45,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Install doctl
         uses: ./
@@ -60,12 +61,13 @@ jobs:
           doctl compute region list 2>&1 | grep -qi "Unable to initialize DigitalOcean API client: access token is required"
 
   test_custom_version_linux_and_mac:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Install doctl
         uses: ./
@@ -82,9 +84,10 @@ jobs:
         run: doctl compute region list
 
   test_custom_version_windows:
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Install doctl
         uses: ./

--- a/dist/index.js
+++ b/dist/index.js
@@ -10954,7 +10954,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
             core.info(`Attempting to download doctl v${requestedVersion}`);
             return await downloadDoctl(requestedVersion, type, architecture);
         } catch (error) {
-            core.warning(`Failed to download requested version v${requestedVersion}, will try recent versions`);
+            core.warning(`Failed to download requested version v${requestedVersion} : ${error.message}, will try recent versions`);
         }
     }
 
@@ -10968,7 +10968,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
             core.info(`Successfully downloaded doctl v${version}`);
             return { installPath, version };
         } catch (error) {
-            core.warning(`Failed to download doctl v${version}, trying next version`);
+            core.warning(`Failed to download doctl v${version} : ${error.message}, trying next version`);
             continue;
         }
     }
@@ -11014,7 +11014,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
             actualVersion = version;
         } catch (error) {
             // If the download fails (e.g., missing artifacts), try fallback versions
-            core.warning(`Failed to download doctl v${version}, trying fallback versions`);
+            core.warning(`Failed to download doctl v${version} : ${error.message}, trying fallback versions`);
             const result = await downloadDoctlWithFallback(requestedVersion, process.platform, process.arch);
             path = await tc.cacheDir(result.installPath, 'doctl', result.version);
             actualVersion = result.version;

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
             core.info(`Attempting to download doctl v${requestedVersion}`);
             return await downloadDoctl(requestedVersion, type, architecture);
         } catch (error) {
-            core.warning(`Failed to download requested version v${requestedVersion}, will try recent versions`);
+            core.warning(`Failed to download requested version v${requestedVersion} : ${error.message}, will try recent versions`);
         }
     }
 
@@ -90,7 +90,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
             core.info(`Successfully downloaded doctl v${version}`);
             return { installPath, version };
         } catch (error) {
-            core.warning(`Failed to download doctl v${version}, trying next version`);
+            core.warning(`Failed to download doctl v${version} : ${error.message}, trying next version`);
             continue;
         }
     }
@@ -136,7 +136,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
             actualVersion = version;
         } catch (error) {
             // If the download fails (e.g., missing artifacts), try fallback versions
-            core.warning(`Failed to download doctl v${version}, trying fallback versions`);
+            core.warning(`Failed to download doctl v${version} : ${error.message}, trying fallback versions`);
             const result = await downloadDoctlWithFallback(requestedVersion, process.platform, process.arch);
             path = await tc.cacheDir(result.installPath, 'doctl', result.version);
             actualVersion = result.version;


### PR DESCRIPTION
**Summary of the Change**

- Updated the main workflow to run on both `pull_request` instead of  `pull_request_target` event, so all tests (including secret-dependent ones) run for pushes(event already present in the workflow) and same-repo PRs, while secret-dependent tests are skipped for fork PRs (where secrets are not available).
- Added a new workflow (`pr-label-gate.yml`) that triggers only for forked PRs and skips for same repo PRs. This workflow checks if a reviewer has added the `post-merge-tests-ack` label, which acknowledges that secret-dependent tests will be verified after merging (when the push event runs in the base repo). 
- The new workflow ensures that fork PRs cannot be merged without explicit reviewer acknowledgment, making the post-merge test verification process clear and auditable.
- This approach maintains security (no secrets exposed to fork PRs) while providing a clear process for reviewers to track and verify secret-dependent tests after merge.
- Additionally fixed existing lint test failure issue.