### PR TITLE
Update Node.js version to 24 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: 'DigitalOcean API Token'
     default: ''
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
  - Move the Action runtime to Node.js 24 (`runs.using: node24`) to stay compatible as GitHub Actions removes support for Node 20.
  - `npm run package` output is unchanged.

  ## Testing
  - `npm run test` (fails: npm could not write logs to `/Users/leo/.npm/_logs`; eslint reports `no-unused-vars` in `main.js` lines 78, 92, 137). This was already present and will address in a follow up PR.