### PR TITLE
Allow optional catch binding

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ export default [...compat.extends("eslint:recommended"), {
             SharedArrayBuffer: "readonly",
         },
 
-        ecmaVersion: 2018,
+        ecmaVersion: 2019,
         sourceType: "commonjs",
     },
 

--- a/main.js
+++ b/main.js
@@ -75,7 +75,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
         try {
             core.info(`Attempting to download doctl v${requestedVersion}`);
             return await downloadDoctl(requestedVersion, type, architecture);
-        } catch (error) {
+        } catch {
             core.warning(`Failed to download requested version v${requestedVersion}, will try recent versions`);
         }
     }
@@ -89,7 +89,7 @@ async function downloadDoctlWithFallback(requestedVersion, type, architecture) {
             const installPath = await downloadDoctl(version, type, architecture);
             core.info(`Successfully downloaded doctl v${version}`);
             return { installPath, version };
-        } catch (error) {
+        } catch {
             core.warning(`Failed to download doctl v${version}, trying next version`);
             continue;
         }
@@ -134,7 +134,7 @@ Failed to retrieve latest version; falling back to: ${fallbackVersion}`);
             const installPath = await downloadDoctl(version, process.platform, process.arch);
             path = await tc.cacheDir(installPath, 'doctl', version);
             actualVersion = version;
-        } catch (error) {
+        } catch {
             // If the download fails (e.g., missing artifacts), try fallback versions
             core.warning(`Failed to download doctl v${version}, trying fallback versions`);
             const result = await downloadDoctlWithFallback(requestedVersion, process.platform, process.arch);


### PR DESCRIPTION
## Summary

 - Remove unused vars to make linter happy
 - Allow optional catch binding by bumping ESLint `ecmaVersion` to 2019.

## Testing

- [x] npm run test

Note: The CI runs only on master so it won't show the result of this fix.