### PR TITLE
Update action runtime to Node 24 and refresh CI to actions/checkout@v5

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: "Ensure that code has been packaged and commited"
+      - name: "Ensure that code has been packaged and committed"
         run: |-
             npm install
             npm run package


### PR DESCRIPTION
## Summary

GitHub Actions is deprecating Node 20 for JavaScript actions and will switch the
default to Node 24 on **June 2, 2026** (Node 20 removed Sep 16, 2026):
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR moves `digitalocean/action-doctl` to Node 24 today so customers stop
seeing the deprecation warning in their pipelines. Builds on the work in
#124 by @lgrosales — opening a fresh PR rather than rebasing #124 onto the
recent `v2` HEAD so we can also include the matching CI cleanup.


## Changes

1. `action.yml`: `runs.using` `node20` → `node24`
2. `.github/workflows/workflow.yml`: `actions/checkout@v4` → `@v5` (×6) — removes
   the matching deprecation warning from our own CI annotations. Internal only,
   no consumer impact.
   
warning message - 
`Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: ./, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

## Why now (not waiting for June 2)

GitHub-hosted runners already accept `using: node24` today as opt-in — the
June 2 date is when it becomes the *default*. Confirmed end-to-end on a
temporary test branch (`test/esc-22321-node24-manifest`):

| Test | Setup | Workflow | Deprecation warnings | Runtime |
|---|---|---|---|---|
| [Baseline](https://github.com/digitalocean/action-doctl/actions/runs/23046647484) | `using: node20`, `checkout@v4` | success | action-doctl + checkout listed | — |
| [Test 1](https://github.com/digitalocean/action-doctl/actions/runs/24734894876) | `using: node24`, `checkout@v4` | success | only checkout (action-doctl gone) | — |
| [Test 2](https://github.com/digitalocean/action-doctl/actions/runs/24735291548) | `using: node24`, `checkout@v5` | success | **0** | — |
| [Test 3](https://github.com/digitalocean/action-doctl/actions/runs/24735602296) | + runtime probe | success | 0 | **Node v24.14.1 confirmed on Linux + macOS + Windows** |

Tool-cache probe confirmed the Node 24 binary is present on every hosted
runner (`/opt/hostedtoolcache/node/24.14.1/x64/bin/node` on Linux,
equivalents on macOS/Windows), proving the runner genuinely interprets
`using: node24` actions on Node 24, not a Node 20 fallback.

## Test plan

- [x] CI green on this branch (12/12 jobs across ubuntu/macos/windows)
- [x] No deprecation warnings emitted by this action when consumed
- [ ] Reviewer to confirm tag/release plan post-merge

## Out of scope

- Pre-existing macOS rate-limit warning from `getLatestRelease` Octokit call
  in `main.js` — fix should be a follow-up PR adding `auth: process.env.GITHUB_TOKEN`
  to the Octokit constructor.
